### PR TITLE
Avoid null value for Wikidata ID

### DIFF
--- a/examples/index_pages.php
+++ b/examples/index_pages.php
@@ -35,5 +35,7 @@ $pagesCount = count( $prideAndPrejudiceIndex->getPageList() );
 $existing = count( $prideAndPrejudiceIndex->getPageList( true ) );
 
 // Output summary.
-echo $prideAndPrejudiceIndex->getTitle() . " has $pagesCount pages ($existing of which exist) "
-	 . "and is of quality '" . $prideAndPrejudiceIndex->getQuality() . "'.\n";
+echo $prideAndPrejudiceIndex->getTitle()
+	. " (on " . $enWs->getDomainName() . ", " . $enWs->getWikidataId() . ") "
+	. "has $pagesCount pages ($existing of which exist) "
+	. "and is of quality '" . $prideAndPrejudiceIndex->getQuality() . "'.\n";

--- a/examples/list.php
+++ b/examples/list.php
@@ -32,5 +32,5 @@ $wsApi->setLogger( $logger );
 $wikisources = $wsApi->fetchWikisources();
 echo count( $wikisources ) . " Wikisources found:\n";
 foreach ( $wikisources as $ws ) {
-	echo "* " . $ws->getLanguageCode() . " - " . $ws->getLanguageName() . "\n";
+	echo "* " . $ws->getLanguageCode() . " - " . $ws->getLanguageName() . " - " . $ws->getWikidataId() . "\n";
 }

--- a/src/Wikisource.php
+++ b/src/Wikisource.php
@@ -121,7 +121,10 @@ class Wikisource {
 	 */
 	public function getWikidataId(): string {
 		if ( !$this->wikidataId ) {
-			$this->getWikisoureApi()->fetchWikisource( $this->getLanguageCode() );
+			// Get another Wikisource object, but via fetchWikisource() to ensure it has a Wikidata ID.
+			$this->wikidataId = $this->getWikisoureApi()
+				->fetchWikisource( $this->getLanguageCode() )
+				->getWikidataId();
 		}
 		return $this->wikidataId;
 	}


### PR DESCRIPTION
Workaround for Fatal error: Uncaught TypeError: Return value of
Wikisource\Api\Wikisource::getWikidataId() must be of the type string,
null returned in src/Wikisource.php:127